### PR TITLE
Added basic license catalog

### DIFF
--- a/licenses/licenses.csv
+++ b/licenses/licenses.csv
@@ -1,0 +1,3 @@
+go.uber.org/atomic,https://github.com/uber-go/atomic/blob/v1.9.0/LICENSE.txt,MIT
+go.uber.org/multierr,https://github.com/uber-go/multierr/blob/v1.8.0/LICENSE.txt,MIT
+go.uber.org/zap,https://github.com/uber-go/zap/blob/v1.21.0/LICENSE.txt,MIT


### PR DESCRIPTION
There will now be a `./licenses/licenses.csv` file that catalogs all the licenses for the dependencies.